### PR TITLE
Eliminate deprecation warnings

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -18,7 +18,7 @@ doctrine:
         url: '%env(resolve:DATABASE_URL)%'
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
-        naming_strategy: doctrine.orm.naming_strategy.underscore
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
         mappings:
             App:

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -3,3 +3,4 @@ twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
     form_themes: ['bootstrap_4_layout.html.twig']
+    exception_controller: null

--- a/src/Command/CreateSuperadmintUserCommand.php
+++ b/src/Command/CreateSuperadmintUserCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
@@ -10,21 +11,22 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 use App\Entity\User;
 
 
-class CreateSuperadmintUserCommand extends ContainerAwareCommand
+class CreateSuperadmintUserCommand extends Command
 {
     protected static $defaultName = 'basicrum:superadmin:create';
 
     private $passwordEncoder;
+    private $entityManager;
 
-    public function __construct(UserPasswordEncoderInterface $passwordEncoder)
+    public function __construct(UserPasswordEncoderInterface $passwordEncoder, EntityManagerInterface $entityManager)
     {
-        $this->passwordEncoder = $passwordEncoder;
+        $this->passwordEncoder  = $passwordEncoder;
+        $this->entityManager    = $entityManager;
         parent::__construct();
     }
 
@@ -38,7 +40,7 @@ class CreateSuperadmintUserCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $em = $this->getContainer()->get('doctrine')->getManager();
+        $em = $this->entityManager;
         $io = new SymfonyStyle($input, $output);
 
         $query = $em->createQuery('SELECT u FROM App\Entity\User u WHERE u.roles LIKE \'%ROLE_ADMIN%\'');

--- a/symfony.lock
+++ b/symfony.lock
@@ -110,6 +110,9 @@
     "jdorn/sql-formatter": {
         "version": "v1.2.17"
     },
+    "laminas/laminas-zendframework-bridge": {
+        "version": "1.0.1"
+    },
     "monolog/monolog": {
         "version": "1.23.0"
     },
@@ -509,6 +512,9 @@
     },
     "twig/twig": {
         "version": "v2.4.8"
+    },
+    "webimpress/safe-writer": {
+        "version": "2.0.0"
     },
     "webmozart/assert": {
         "version": "1.3.0"


### PR DESCRIPTION
Hello @ceckoslab 
Here are modifications required in order to get rid of deprecation warnings after symfony upgrade to version 5. 
Not so many changes really, but took some time to find out what exactly and where to change 