### PR TITLE
#119: reset .env file on rebuild/init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
     - stage: build_and_test
       script:
         # build
-        - mv -f .env.travis .env
+        - mv -f .env.travis docker/symfony_app/.env
         - make up
         - make init_script
         - make cc

--- a/init.sh
+++ b/init.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ ! -f ".env" ]; then
-  cp docker/symfony_app/.env .env
-fi
+cp docker/symfony_app/.env .env
 
 composer install --no-interaction;
 


### PR DESCRIPTION
We decided to force replacement of `.env` file every time on `make rebuild` as we anyway resetting all the other data/configuration to defaults.