### PR TITLE
Fix issue with rewriting DB connection by env variable in container when running tests

### DIFF
--- a/.env.travis
+++ b/.env.travis
@@ -19,5 +19,5 @@ APP_SECRET=a61405770c0c9097569cd6c494a60a7b
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Configure your db driver and server_version in config/packages/doctrine.yaml
-# DATABASE_URL=mysql://root:rootsecret@db:3306/basicrum_demo
+DATABASE_URL=mysql://basic:rum@db:3306/basicrum_demo
 ###< doctrine/doctrine-bundle ###

--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,4 +1,0 @@
-doctrine:
-  dbal:
-    url: 'mysql://root@db:3306/basicrum_test'
-

--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,0 +1,4 @@
+doctrine:
+  dbal:
+    url: 'mysql://root@db:3306/basicrum_test'
+

--- a/docker/app.env
+++ b/docker/app.env
@@ -1,3 +1,2 @@
 CATCHER_ENDPOINT=http://test11:test22@172.27.0.1/excavator/digger.php
 MONITORED_ORIGIN=www.darvart.de
-DATABASE_URL=mysql://basic:rum@db:3306/basicrum_demo

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,6 @@
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
-         backupGlobals="false"
          colors="true"
          bootstrap="tests/bootstrap.php"
 >
@@ -15,7 +14,7 @@
         <env name="APP_DEBUG" value="1" />
         <env name="APP_SECRET" value="s$cretf0rt3st" />
         <env name="SHELL_VERBOSITY" value="-1" />
-        <env name="DATABASE_URL" value="mysql://root:rootsecret@db:3306/basic_rum_test_db" />
+        <env name="DATABASE_URL" value="mysql://root@db:3306/basic_rum_test_db" />
         <env name="BOOTSTRAP_RESET_DATABASE" value="1" />
         <!-- define your env variables for the test env here -->
 


### PR DESCRIPTION
Hi guys, 
I realised that when you run tests on your local env it's actually using the same db and reset data in the local DB: at least admin user, as I can not login with my credentials after tests has been executed. 
I've created a separate configuration file for test env which should rewrite the DB connection URL for doctrine. 