### PR TITLE
Install xdebug for local environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ up: ## Start local environment
 down: ## Stop local environment
 	docker-compose -f ${dc_path} down
 
+restart: down up # Restart environment
+
 rebuild: ## Rebuild local environment from scratch
 	@/bin/echo -n "All the volumes will be deleted. You will loose data in DB. Are you sure? [y/N]: " && read answer && \
 	[[ $${answer:-N} = y ]] && make destroy && make init

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,12 +7,15 @@ services:
     build:
       context: symfony_app
       dockerfile: Dockerfile
+      args:
+        XDEBUG_ON: "${XDEBUG_ON:-N}" # just add XDEBUG_ON=Y to your .env and `make restart`
     container_name: basicrum_bo_php
     env_file:
       - app.env
     volumes:
       - ./..:/var/www/html:delegated
       - ./symfony_app/www.conf:/usr/local/etc/php-fpm.d/www.conf # local dev only, should not be used for production
+      - ./symfony_app/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini # local dev only, should not be used for production
     command: # local dev only, should not be used for production
       - "php-fpm"
       - "-R"

--- a/docker/symfony_app/Dockerfile
+++ b/docker/symfony_app/Dockerfile
@@ -9,6 +9,15 @@ RUN apk add --no-cache zip bash libzip \
     && docker-php-ext-install pdo_mysql zip  \
     && apk del --purge .build-deps
 
+# Install xdebug if required
+ARG XDEBUG_ON="N"
+RUN if [ "${XDEBUG_ON}" == "Y" ]; then \
+    apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del --purge .phpize-deps; \
+ fi
+
 # install composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
     && php composer-setup.php --filename=composer --install-dir=/usr/local/bin \

--- a/docker/symfony_app/xdebug.ini
+++ b/docker/symfony_app/xdebug.ini
@@ -1,0 +1,3 @@
+xdebug.remote_enable=1
+xdebug.remote_connect_back=0
+xdebug.remote_host=host.docker.internal


### PR DESCRIPTION
Hi guys, 
So far we haven't had an easy way to enable/disable xdebug.
I've added XDEBUG_ON parameter which is defining if xdebug extension should be installed in the container. It can be easily tweaked by adding `XDEBUG_ON=Y` to you .env file(which is ignored by git) or by configuring environment variable in your shell: `export XDEBUG_ON=Y`. 
To apply changes we need to restart the env by `make restart` as rebuild of symfony_app is required in this case. 