### PR TITLE
Better session and logout by timeout handling mechanism

### DIFF
--- a/public/js/basicrum.js
+++ b/public/js/basicrum.js
@@ -109,6 +109,7 @@
             }
 
             // don't allow a handler to be attached more than once to the same event
+            ev = impl.events[e_name];
             for (i = 0; i < impl.events[e_name].length; i++) {
                 handler = ev[i];
                 if (handler && handler.fn === fn && handler.cb_data === cb_data && handler.scope === cb_scope) {

--- a/public/js/user/autologout.js
+++ b/public/js/user/autologout.js
@@ -43,7 +43,7 @@ sessionCountdownTimer = (function(){
      */
     var setEvent = function(){
         if (ajaxEvent === false) {
-            BASIC_RUM_APP.subscribe("load_content", function(){
+            BASIC_RUM_APP.subscribe("dynamic_content_loaded", function(){
                 stop();
                 reset();
                 start();

--- a/public/js/user/autologout.js
+++ b/public/js/user/autologout.js
@@ -1,36 +1,195 @@
-var logoutTimer = (function($){
+sessionCountdownTimer = (function(){
+    var startTime = 0,
+        thresholdTime = 0,
+        elementId = '',
+        thresholdCallback,
+        finalCallback,
+        timeLeft = 0,
+        interval,
+        ajaxEvent = false;
 
-    var innerTimer,
-        timeOut = 1000 * 60 * 5; // set timeout to 5 mins
+    /**
+     * This callback type is called `thresholdCallback`
+     * @callback thresholdCallbackParam
+     * @param {number} time Time left to zero
+     */
 
+    /**
+     * This callback type is called `finalCallback`
+     * @callback finalCallbackParam Callback to call when 0 is reached
+     *
+     */
 
+    /**
+     * Setup countdown timer
+     * @param {number} startTimeParam Time in seconds to start countdown from
+     * @param {number} thresholdParam The value when thresholdCallback will be called
+     * @param {string} elementIdParam The element on the page, reflects time left to 0. Can be null
+     * @param {thresholdCallback} thresholdCallbackParam The callback function is called when lets say 5 minutes left to 0. Can be null
+     * @param {finalCallback} finalCallbackParam The callback function is called when 0 is reached. Can be null
+     */
+    var setup = function(startTimeParam, thresholdParam=null, elementIdParam=null, thresholdCallbackParam=null, finalCallbackParam=null) {
+        startTime = startTimeParam;
+        timeLeft = startTimeParam;
+        thresholdTime = thresholdParam;
+        elementId = elementIdParam;
+        thresholdCallback = thresholdCallbackParam;
+        finalCallback = finalCallbackParam;
+        setEvent();
+    };
+
+    /**
+     * Setup an event
+     */
     var setEvent = function(){
-        $(document).ajaxSuccess(function() {
-            stopTimer();
-            startTimer();
-        });
+        if (ajaxEvent === false) {
+            BASIC_RUM_APP.subscribe("load_content", function(){
+                stop();
+                reset();
+                start();
+            });
+
+            ajaxEvent = true;
+        }
     };
 
-    var startTimer = function(){
-        innerTimer = setTimeout('logoutTimer.logOut()', timeOut);
+    /**
+     * Start timer
+     */
+    var start = function() {
+        if (startTime > 0) {
+            interval = setInterval(function(){
+                if (timeLeft > 0) {
+                    timeLeft = --timeLeft;
+                }
+                else {
+                    stop();
+                    logout();
+                }
+
+                if ((timeLeft % 20) === 0) {
+                    checkSession();
+                }
+
+                if (elementId) {
+                    $('#'+elementId).html(secondsToHms(timeLeft));
+                }
+
+                if (thresholdTime && thresholdCallback) {
+                    if (timeLeft === thresholdTime) {
+                        thresholdCallback();
+                    }
+                }
+
+            }, 1000);
+        }
     };
 
-    var stopTimer = function(){
-        clearTimeout(innerTimer);
+    /**
+     * Convert amount of seconds to formatted string H hour(s), i minute(s), s second(s)
+     * @param seconds
+     * @returns {string} Formatted output H hour(s), i minute(s), s second(s)
+     */
+    var secondsToHms = function(seconds) {
+        seconds = Number(seconds);
+        var h = Math.floor(seconds / 3600);
+        var m = Math.floor(seconds % 3600 / 60);
+        var s = Math.floor(seconds % 3600 % 60);
+
+        var hDisplay = h > 0 ? h + (h === 1 ? " hour, " : " hours, ") : "";
+        var mDisplay = m > 0 ? m + (m === 1 ? " minute, " : " minutes, ") : "";
+        var sDisplay = s > 0 ? s + (s === 1 ? " second" : " seconds") : "0 seconds";
+
+        return hDisplay + mDisplay + sDisplay;
     };
 
-    var logOut = function(){
-        alert("Session is expired!");
+    /**
+     * Stop timer
+     */
+    var stop = function() {
+        clearInterval(interval);
+    };
+
+    /**
+     * Reset timer to initially passed value
+     */
+    var reset = function() {
+        timeLeft = startTime;
+    };
+
+    var checkSession = function() {
+        $.get('/admin/user/check-session')
+            .done(function(response){
+                if ('success' !== response.status ) {
+                    alert("Session is died. \nYou will be redirected to login page");
+                    logout();
+                }
+            })
+            .fail(function(){
+                // TODO: Maybe redirect to logout besides this message ??
+                alert('Something went wrong');
+            });
+    }
+
+    var logout = function(){
         document.location.href = '/logout';
     };
 
     return {
-        setEvent:   setEvent,
-        startTimer: startTimer,
-        logOut:     logOut,
+        setup: setup,
+        start: start,
+        stop: stop,
+        reset: reset,
+        checkSession: checkSession,
+        setEvent: setEvent,
     };
-})(jQuery);
+})();
 
-logoutTimer.setEvent();
-logoutTimer.startTimer();
+var sessionTimeoutModal = (function(){
+    /**
+     * Modal id
+     * @type {string}
+     */
+    var modalId = "#sessionWarningModal";
+    var continueButtonEventListener = false;
+
+    /**
+     * Show modal
+     */
+    var showModal = function() {
+        setupEventListener();
+        $(modalId).modal("show");
+    };
+
+    /**
+     * Event listener for continue session button
+     */
+    var setupEventListener = function() {
+
+        // make sure we set it up only once
+        if (!continueButtonEventListener) {
+            $("#modal-session-continue").on('click', function () {
+                sessionCountdownTimer.checkSession();
+                sessionCountdownTimer.reset();
+                hideModal();
+            });
+            continueButtonEventListener = true;
+        }
+    };
+
+    /**
+     * Hide modal
+     */
+    var hideModal = function() {
+        $(modalId).modal("hide");
+    };
+
+    return {
+        show: showModal,
+    };
+})();
+
+sessionCountdownTimer.setup(1800, 300, 'session_timer', sessionTimeoutModal.show);
+sessionCountdownTimer.start();
+
 

--- a/src/Controller/Admin/UsersController.php
+++ b/src/Controller/Admin/UsersController.php
@@ -122,4 +122,26 @@ class UsersController extends AbstractController
             ],
         ]);
     }
+
+    /**
+     * @Route("/admin/user/check-session", name="admin_check_session")
+     */
+    public function checkSession()
+    {
+        try {
+            if (PHP_SESSION_ACTIVE != session_status() || !$this->getUser()->getId()) {
+                throw new \Exception('Session is not active');
+            }
+
+            return $this->json([
+                'status' => 'success',
+                'message' => 'Session is Alive',
+            ]);
+        } catch (\Throwable $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'Session Error',
+            ]);
+        }
+    }
 }

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -208,6 +208,7 @@
             </footer>
         </div>
     </div>
+
     <!--End Container-->
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <!--<script src="http://code.jquery.com/jquery.js"></script>-->
@@ -231,6 +232,22 @@
     <script>
         BASIC_RUM_APP.init();
     </script>
+
+    <!-- The Session Expiration Countdown Modal -->
+    <div class="modal fade" id="sessionWarningModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-body text-right">
+                    <div>Your session is about to expire in <span id="session_timer" class="text-danger"></span></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="modal-session-continue">Extend Session</button>
+                    <a href="{{ path('app_logout') }}"><button type="button" class="btn btn-danger" id="modal-logout-button">Logout</button></a>
+                </div>
+
+            </div>
+        </div>
+    </div>
 
     </body>
 </html>


### PR DESCRIPTION
Hello @ceckoslab 
Here is almost done new session control logic.
The only problem left is session timer reset on page content loading.

I'd like to attach session timer reset function to one of events happened on page content load: load_content or dynamic_content_loaded. However it is not possible because of restriction in basicrum.js :
```
            // don't allow a handler to be attached more than once to the same event
            for (i = 0; i < impl.events[e_name].length; i++) {
                handler = ev[i];
                if (handler && handler.fn === fn && handler.cb_data === cb_data && handler.scope === cb_scope) {
                    return this;
                }
            }
```

What was the logic behind this code / limitation? Can I remove it? Should I improve it?  From what I've seen within testing it under different conditions it's not working anyway. If there is only one event listener for same event then the code within for loop is never run. However if there are two or more event listeners for the same event its throwing an error:
>basicrum.js:113 Uncaught TypeError: Cannot read property '0' of undefined
    at Object.subscribe (basicrum.js:113)
    at Object.init (content_loader.js:45)
    at Object.init (basicrum.js:139)
    at (index):220
subscribe @ basicrum.js:113
init @ content_loader.js:45
init @ basicrum.js:139
(anonymous) @ (index):220

Because variable ev declared but not initialized


Another possible workaround is to fire another event right before or after 
```
BASIC_RUM_APP.fireEvent('dynamic_content_loaded');
```
which is not good at all. 

What you think?